### PR TITLE
Fix Prism URL & AdvancedBan spelling

### DIFF
--- a/src/content/docs/en/recommended-plugins.mdx
+++ b/src/content/docs/en/recommended-plugins.mdx
@@ -17,7 +17,7 @@ PlaceholderAPI is a plugin/library that allows servers to use placeholders from 
 ## [LuckPerms](https://luckperms.net) (permissions)
 LuckPerms is a feature-rich, yet still incredibly easy to use permissions manager. A permissions plugin allows you to grant specific players & groups permission to either do, or specifically not do something, where something is an action or command defined in another plugin. Because most plugins use permissions in some form, a permissions plugin is almost always a requirement. LuckPerms also supports complex permission setups, works with proxy software, and has great debugging tools.
 
-## [CoreProtect](https://www.spigotmc.org/resources/coreprotect.8631/) or [Prism](https://www.spigotmc.org/resources/prism.75166/) (grief protection)
+## [CoreProtect](https://www.spigotmc.org/resources/coreprotect.8631/) or [Prism](https://www.spigotmc.org/resources/prism.99397/) (grief protection)
 CoreProtect is an administration and anti-griefing tool that makes it super easy for moderators/administrators to quickly identify who broke a specific block, took an item from a chest, placed a block, lit the TNT, etc. It supports storing the log into a database, and rolling back based on configurable filters such as “rollback everything done by Notch in the last 5 minutes in this 20 block radius”. It’ll quickly become your go-to anti-grief tool.
 
 
@@ -29,7 +29,7 @@ Essentials is a catch-all plugin for common server mechanics without having to i
 ## [LiteBans](https://www.spigotmc.org/resources/litebans.3715/) (punishment management)
 LiteBans is a versatile and lightweight punishment plugin supporting UUIDs that allows temporary and permanent bans, kicks, mutes, warnings, and more. It also has an easy-to-install web interface.
 
-## [AdvanceBans](https://www.spigotmc.org/resources/advancedban.8695/) (punishment management)
+## [AdvancedBan](https://www.spigotmc.org/resources/advancedban.8695/) (punishment management)
 AdvanceBans is similar to Litebans but is open source and free to anyone to use or modify. It is lightweight and supports UUIDs to ban, kick, mute, and warn. However, it does not have its own web interface you can hook up.
 
 ## [WorldEdit](https://dev.bukkit.org/projects/worldedit) (in-game world editor)


### PR DESCRIPTION
- Updated the URL of the Prism Grief Protection plugin to the new version
- Used the correct spelling for AdvancedBan